### PR TITLE
Increase KB fact readability

### DIFF
--- a/src/tlang/KnowledgeBase.java
+++ b/src/tlang/KnowledgeBase.java
@@ -147,10 +147,10 @@ private static final String relativeDir = "./";
 public static final String and = " /\\ ";
 /** The logical disjunction operator, OR, is written as <code>\/</code> in the first-order predicate
  * language for the KnowledgeBase and the Prolog prover. */
-public static final String or = "\\/";
+public static final String or = " \\/ ";
 /** The logical negation operator, NOT, is written as <code>-</code> in the first-order predicate
  * language for the KnowledgeBase and the Prolog prover */
-public static final String not = "-";
+public static final String not = " -";
 
 
 /** The result of an attempted proof will be one of:


### PR DESCRIPTION
Add spaces to KnowledgeBase's language for facts in order to make them a little more readable.

(This is the second time that I've done this merge and I don't know why it is needed.)